### PR TITLE
Add retry support

### DIFF
--- a/ZenPacks/zenoss/PagerDuty/actions.py
+++ b/ZenPacks/zenoss/PagerDuty/actions.py
@@ -148,9 +148,10 @@ class PagerDutyEventsAPIAction(IActionBase):
         try:
             bodyWithProcessedTalesExpressions['payload']['severity'] = EVENT_MAPPING[bodyWithProcessedTalesExpressions['payload']['severity']]
         except KeyError:
-            severity = bodyWithProcessedTalesExpressions['payload']['severity']
-            if severity in EVENT_MAPPING.values():
-                bodyWithProcessedTalesExpressions['payload']['severity'] = severity
+            if bodyWithProcessedTalesExpressions['payload']['severity'] in EVENT_MAPPING.values():
+                pass
+            else:
+                raise
         except Exception:
             raise
 

--- a/ZenPacks/zenoss/PagerDuty/actions.py
+++ b/ZenPacks/zenoss/PagerDuty/actions.py
@@ -144,7 +144,16 @@ class PagerDutyEventsAPIAction(IActionBase):
         dmdRoot = _dmdRoot(self.dmd)
         apiTimeout = getattr(dmdRoot, ACCOUNT_ATTR).apiTimeout
         bodyWithProcessedTalesExpressions = self._processTalExpressions(body, environ)
-        bodyWithProcessedTalesExpressions['payload']['severity'] = EVENT_MAPPING[bodyWithProcessedTalesExpressions['payload']['severity']]
+
+        try:
+            bodyWithProcessedTalesExpressions['payload']['severity'] = EVENT_MAPPING[bodyWithProcessedTalesExpressions['payload']['severity']]
+        except KeyError:
+            severity = bodyWithProcessedTalesExpressions['payload']['severity']
+            if severity in EVENT_MAPPING.values():
+                bodyWithProcessedTalesExpressions['payload']['severity'] = severity
+        except Exception:
+            raise
+
         requestBody = json.dumps(bodyWithProcessedTalesExpressions)
 
         headers = {'Content-Type': 'application/json'}

--- a/ZenPacks/zenoss/PagerDuty/actions.py
+++ b/ZenPacks/zenoss/PagerDuty/actions.py
@@ -7,7 +7,6 @@
 #
 ##############################################################################
 import json
-from http import HTTPStatus
 import urllib2
 from requests import PagerDutyRequestLimitExceeded
 from retry import retry
@@ -161,7 +160,7 @@ class PagerDutyEventsAPIAction(IActionBase):
             elif hasattr(e, 'code'):
                 msg = 'The PagerDuty server couldn\'t fulfill the request: HTTP %d (%s)' % (e.code, e.msg)
 
-                if e.code == HTTPStatus.TOO_MANY_REQUESTS:
+                if e.code == 429:
                     raise PagerDutyRequestLimitExceeded(msg)
                 else:
                     raise ActionExecutionException(msg)

--- a/ZenPacks/zenoss/PagerDuty/requests.py
+++ b/ZenPacks/zenoss/PagerDuty/requests.py
@@ -23,6 +23,8 @@ class InvalidTokenException(Exception):
 class PagerDutyUnreachableException(Exception):
     pass
 
+class PagerDutyRequestLimitExceeded(Exception):
+    pass
 
 class ParseException(Exception):
     pass

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ AUTHOR = "Zenoss"
 LICENSE = ""
 NAMESPACE_PACKAGES = ['ZenPacks', 'ZenPacks.zenoss']
 PACKAGES = ['ZenPacks', 'ZenPacks.zenoss', 'ZenPacks.zenoss.PagerDuty']
-INSTALL_REQUIRES = []
+INSTALL_REQUIRES = ['retry']
 COMPAT_ZENOSS_VERS = ">= 4.2.5"
 PREV_ZENPACK_NAME = "ZenPacks.PagerDuty.APINotification"
 # STOP_REPLACEMENTS


### PR DESCRIPTION
## Problem
 
When a major outage happens Zenoss can run up against PagerDuty [rate-limiting](https://developer.pagerduty.com/docs/rest-api-v2/rate-limiting/) causing events to be lost.
 
## Solution
 
Add the [retry](https://pypi.org/project/retry/) decorator to the zenpack to watch for a http status code of `429 Too Many Requests` from PagerDuty, then backoff attempts for until we are back within the rate limit window.
 
## Testing
 
To test this we need to install the plugin and then block traffic with iptables to monitor. This has all been done on the backup instance so don't attempt but for the record this is what I did to test:

```sh
# become the zenoss user
sudo su - zenoss

# clone this repo
git clone git@github.com:merit-network/ZenPacks.zenoss.PagerDuty.git
cd ZenPacks.zenoss.PagerDuty/
git checkout add-retry-support

# remove existing zenpack
zenpack --remove ZenPacks.zenoss.PagerDuty

# install this zenpack
zenpack --install --link ZenPacks.zenoss.PagerDuty

# restart zenoss to load the zenpack
zenoss restart

# drop all outbound icmp traffic
sudo iptables -A OUTPUT -p icmp -j DROP

# drop all outbound snmp traffic
sudo iptables -A OUTPUT -p udp --dport 161 -j DROP

# monitor the alerts from zenactiond
tail -f /opt/zenoss/log/zenactiond.log

# watch for lines like (this will take sometime to hit though)
2021-06-04 14:17:53,621 WARNING retry.api: The PagerDuty server couldn't fulfill the request: HTTP 429 (Too Many Requests), retrying in 60 seconds...
```
